### PR TITLE
Added `type` attribute to existing components

### DIFF
--- a/definitions/elasticsearch-logstash-kibana/component.json
+++ b/definitions/elasticsearch-logstash-kibana/component.json
@@ -1,11 +1,13 @@
 {
   "name": "elasticsearch-logstash-kibana",
   "generator": "static",
+  "type": "static",
   "path": "./manifests",
   "subcomponents": [
     {
       "name": "elasticsearch",
       "generator": "helm",
+      "type": "helm",
       "source": "https://github.com/helm/charts",
       "method": "git",
       "path": "stable/elasticsearch"
@@ -13,6 +15,7 @@
     {
       "name": "elasticsearch-curator",
       "generator": "helm",
+      "type": "helm",
       "source": "https://github.com/helm/charts",
       "method": "git",
       "path": "stable/elasticsearch-curator"
@@ -20,6 +23,7 @@
     {
       "name": "logstash",
       "generator": "helm",
+      "type": "helm",
       "source": "https://github.com/helm/charts",
       "method": "git",
       "path": "stable/logstash"
@@ -27,6 +31,7 @@
     {
       "name": "kibana",
       "generator": "helm",
+      "type": "helm",
       "source": "https://github.com/helm/charts",
       "method": "git",
       "path": "stable/kibana"

--- a/definitions/fabrikate-bookinfo/component.yaml
+++ b/definitions/fabrikate-bookinfo/component.yaml
@@ -1,3 +1,4 @@
 name: bookinfo
-generator: helm
+generator: helm # Deprecated in fabrikate v1.0.0
+type: helm # Replaces `generator` in fabrikate v1.0.0
 path: ./charts/bookinfo

--- a/definitions/fabrikate-cloud-native/component.yaml
+++ b/definitions/fabrikate-cloud-native/component.yaml
@@ -1,5 +1,6 @@
 name: "cloud-native"
-generator: "static"
+generator: static # Deprecated in fabrikate v1.0.0
+type: static # Replaces `generator` in fabrikate v1.0.0
 path: "./manifests"
 subcomponents:
   - name: "elasticsearch-fluentd-kibana"

--- a/definitions/fabrikate-elasticsearch-fluentd-kibana/component.json
+++ b/definitions/fabrikate-elasticsearch-fluentd-kibana/component.json
@@ -1,11 +1,13 @@
 {
   "name": "elasticsearch-fluentd-kibana",
   "generator": "static",
+  "type": "static",
   "path": "./manifests",
   "subcomponents": [
     {
       "name": "elasticsearch",
       "generator": "helm",
+      "type": "helm",
       "source": "https://github.com/helm/charts",
       "method": "git",
       "path": "stable/elasticsearch"
@@ -13,6 +15,7 @@
     {
       "name": "elasticsearch-curator",
       "generator": "helm",
+      "type": "helm",
       "source": "https://github.com/helm/charts",
       "method": "git",
       "path": "stable/elasticsearch-curator"
@@ -20,6 +23,7 @@
     {
       "name": "fluentd-elasticsearch",
       "generator": "helm",
+      "type": "helm",
       "source": "https://github.com/helm/charts",
       "method": "git",
       "path": "stable/fluentd-elasticsearch"
@@ -27,6 +31,7 @@
     {
       "name": "kibana",
       "generator": "helm",
+      "type": "helm",
       "source": "https://github.com/helm/charts",
       "method": "git",
       "path": "stable/kibana"

--- a/definitions/fabrikate-istio/component.yaml
+++ b/definitions/fabrikate-istio/component.yaml
@@ -1,5 +1,6 @@
 name: istio
-generator: helm
+generator: helm # Deprecated in fabrikate v1.0.0
+type: helm # Replaces `generator` in fabrikate v1.0.0
 path: "./tmp/istio-1.1.5/install/kubernetes/helm/istio"
 hooks:
   before-install:
@@ -10,8 +11,10 @@ hooks:
     - rm istio.tar.gz
 subcomponents:
   - name: istio-namespace
-    generator: static
+    generator: static # Deprecated in fabrikate v1.0.0
+    type: static # Replaces `generator` in fabrikate v1.0.0
     path: ./manifests
   - name: istio-crd # 1.1 split out CRDs to seperate chart
-    generator: helm
+    generator: helm # Deprecated in fabrikate v1.0.0
+    type: helm # Replaces `generator` in fabrikate v1.0.0
     path: "./tmp/istio-1.1.5/install/kubernetes/helm/istio-init"

--- a/definitions/fabrikate-jaeger/component.json
+++ b/definitions/fabrikate-jaeger/component.json
@@ -1,11 +1,13 @@
 {
   "name": "fabrikate-jaeger",
   "generator": "static",
+  "type": "static",
   "path": "./manifests",
   "subcomponents": [
     {
       "name": "jaeger",
       "generator": "helm",
+      "type": "helm",
       "repositories": {
         "incubator": "https://kubernetes-charts-incubator.storage.googleapis.com/"
       },

--- a/definitions/fabrikate-keyvault-flexvolume/component.yaml
+++ b/definitions/fabrikate-keyvault-flexvolume/component.yaml
@@ -1,5 +1,6 @@
 name: keyvault-flexvolume
-generator: "static"
+generator: static # Deprecated in fabrikate v1.0.0
+type: static # Replaces `generator` in fabrikate v1.0.0
 path: "./tmp"
 hooks:
   before-install:

--- a/definitions/fabrikate-kured/component.yaml
+++ b/definitions/fabrikate-kured/component.yaml
@@ -1,9 +1,11 @@
 name: "kured"
-generator: "helm"
+generator: helm # Deprecated in fabrikate v1.0.0
+type: helm # Replaces `generator` in fabrikate v1.0.0
 source: "https://github.com/helm/charts"
 method: "git"
 path: "stable/kured"
 subcomponents:
   - name: "static"
-    generator: "static"
+    generator: static # Deprecated in fabrikate v1.0.0
+    type: static # Replaces `generator` in fabrikate v1.0.0
     path: "./manifests"

--- a/definitions/fabrikate-prometheus-grafana/component.yaml
+++ b/definitions/fabrikate-prometheus-grafana/component.yaml
@@ -1,15 +1,18 @@
 name: "prometheus-grafana"
-generator: "static"
+generator: static # Deprecated in fabrikate v1.0.0
+type: static # Replaces `generator` in fabrikate v1.0.0
 path: "./manifests"
 subcomponents:
   - name: "grafana"
-    generator: "helm"
+    generator: helm # Deprecated in fabrikate v1.0.0
+    type: helm # Replaces `generator` in fabrikate v1.0.0
     source: "https://github.com/helm/charts"
     method: "git"
     path: "stable/grafana"
     version: "247a3076790511b21000f4071e41bbf6bf4a8fc4"
   - name: "prometheus"
-    generator: "helm"
+    generator: helm # Deprecated in fabrikate v1.0.0
+    type: helm # Replaces `generator` in fabrikate v1.0.0
     source: "https://github.com/helm/charts"
     method: "git"
     path: "stable/prometheus"

--- a/definitions/fabrikate-velero/component.yaml
+++ b/definitions/fabrikate-velero/component.yaml
@@ -1,9 +1,11 @@
 name: "velero"
-generator: "helm"
+generator: helm # Deprecated in fabrikate v1.0.0
+type: helm # Replaces `generator` in fabrikate v1.0.0
 source: "https://github.com/helm/charts"
 method: "git"
 path: "stable/velero"
 subcomponents:
   - name: "static"
-    generator: "static"
+    generator: static # Deprecated in fabrikate v1.0.0
+    type: static # Replaces `generator` in fabrikate v1.0.0
     path: "./manifests"

--- a/definitions/linkerd/component.yaml
+++ b/definitions/linkerd/component.yaml
@@ -1,9 +1,11 @@
 name: fabrikate-linkerd
-generator: static
+generator: static # Deprecated in fabrikate v1.0.0
+type: static # Replaces `generator` in fabrikate v1.0.0
 path: "./manifests"
 subcomponents:
   - name: linkerd
-    generator: static
+    generator: static # Deprecated in fabrikate v1.0.0
+    type: static # Replaces `generator` in fabrikate v1.0.0
     path: "./manifests"
     hooks:
       before-install:


### PR DESCRIPTION
- Marked `generator` as deprecated in v1.0.0 of fabrikate
- Replicated existing `generator` fields as `type` fields in all components