### PR TITLE
Fixed broken tests

### DIFF
--- a/definitions/fabrikate-keyvault-flexvolume/component.yaml
+++ b/definitions/fabrikate-keyvault-flexvolume/component.yaml
@@ -5,5 +5,5 @@ path: "./tmp"
 hooks:
   before-install:
     - curl -OL https://raw.githubusercontent.com/Azure/kubernetes-keyvault-flexvol/master/deployment/kv-flexvol-installer.yaml
-    - mkdir tmp
+    - mkdir -p tmp
     - mv kv-flexvol-installer.yaml tmp

--- a/test/general_test.go
+++ b/test/general_test.go
@@ -1,11 +1,14 @@
 package test
 
 import (
+	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/microsoft/fabrikate/cmd"
+	"github.com/stretchr/testify/assert"
 )
 
 func getAllComponentDirectories() ([]string, error) {
@@ -35,18 +38,25 @@ func getAllComponentDirectories() ([]string, error) {
 // Test that all components in /definitions can be Install and Generate correctly
 func TestInstallAndGenerate(t *testing.T) {
 	components, err := getAllComponentDirectories()
-	if err != nil {
-		t.Error(err.Error())
-	}
+	assert.Nil(t, err)
 
 	for _, component := range components {
+		t.Logf("Starting tests on %s", component)
+		// Clean: Must clean files from ALL components in this repository for every install/generate as previous installs can break new install
+		for _, dir := range []string{"helm_repos", "components", "generated"} {
+			for _, componentDirToClean := range components {
+				err = os.RemoveAll(path.Join(componentDirToClean, dir))
+				assert.Nil(t, err)
+			}
+		}
+
+		// Install
 		err = cmd.Install(component)
-		if err != nil {
-			t.Error(err.Error())
-		}
+		assert.Nil(t, err)
+
+		// Generate
 		_, err = cmd.Generate(component, []string{"common"}, false)
-		if err != nil {
-			t.Error(err.Error())
-		}
+		assert.Nil(t, err)
+		t.Logf("Completed tests on %s", component)
 	}
 }


### PR DESCRIPTION
Tests were failing due to a a cleanup error. As the test script iterated through the definitions to install/generate, some of the following definitions would reference previously iterated definitions; those of which `helm_repos` and `components` directories were not deleted. This would cause git errors as it would attempt to clone the repository again into a directory already containing a git repo.