### PR TITLE
Locking traefik helm chart to helm2 compatible version for fabrikate

### DIFF
--- a/definitions/traefik2/component.yaml
+++ b/definitions/traefik2/component.yaml
@@ -5,4 +5,4 @@ subcomponents:
     source: https://github.com/containous/traefik-helm-chart
     method: git
     path: traefik
-    branch: master
+    version: 43d63f418836d7aaac03cfca5b54f4287c8acf9c


### PR DESCRIPTION
Pin the helm chart for traefik to https://github.com/containous/traefik-helm-chart/commit/43d63f418836d7aaac03cfca5b54f4287c8acf9c

Resolves https://github.com/microsoft/bedrock/issues/1109

