### PR TITLE
aad-pod-identity definition

### DIFF
--- a/.azure/azure-pipelines.yaml
+++ b/.azure/azure-pipelines.yaml
@@ -1,32 +1,24 @@
 pool:
-  vmImage: "Ubuntu-16.04"
+  vmImage: "ubuntu-latest"
 
 variables:
-  GOBIN: "$(GOPATH)/bin" # Go binaries path
-  GOROOT: "/usr/local/go1.13" # Go installation path
-  GOPATH: "$(system.defaultWorkingDirectory)/gopath" # Go workspace path
-  modulePath: "$(GOPATH)/src/github.com/$(build.repository.name)" # Path to the module's code
   GO111MODULE: "on"
 
 steps:
-  - script: |
-      mkdir -p '$(GOBIN)'
-      mkdir -p '$(GOPATH)/pkg'
-      mkdir -p '$(modulePath)'
-      shopt -s extglob
-      shopt -s dotglob
-      mv !(gopath) '$(modulePath)'
-      echo '##vso[task.prependpath]$(GOBIN)'
-      echo '##vso[task.prependpath]$(GOROOT)/bin'
-    displayName: "Set up the Go workspace"
+  - task: GoTool@0
+    inputs:
+      version: '1.13.15'
 
-  - script: |
-      go version
-      go mod download
-    workingDirectory: "$(modulePath)"
-    displayName: "Get dependencies"
+  - task: Go@0
+    displayName: 'Get Dependencies'
+    inputs:
+      command: 'mod'
+      arguments: 'download'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
 
-  - script: |
-      go test -v ./test/...
-    workingDirectory: "$(modulePath)"
-    displayName: "Test"
+  - task: Go@0
+    displayName: 'Test'
+    inputs:
+      command: 'test'
+      arguments: '-v ./test/...'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'

--- a/.azure/azure-pipelines.yaml
+++ b/.azure/azure-pipelines.yaml
@@ -6,8 +6,14 @@ variables:
 
 steps:
   - task: GoTool@0
+    displayName: 'Install Go v1.13.15'
     inputs:
-      version: '1.13.15'
+      version: '1.13.15' # should match go version in go.mod
+
+  - task: HelmInstaller@1
+    displayName: 'Install Helm'
+    inputs:
+      helmVersionToInstall: '2.14.3' # should match dependency in go.sum
 
   - task: Go@0
     displayName: 'Get Dependencies'

--- a/.azure/azure-pipelines.yaml
+++ b/.azure/azure-pipelines.yaml
@@ -16,6 +16,15 @@ steps:
       arguments: 'download'
       workingDirectory: '$(System.DefaultWorkingDirectory)'
 
+  - script: |
+      which go
+      go version
+
+      which helm
+      helm version
+    displayName: 'Versions'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+
   - task: Go@0
     displayName: 'Test'
     inputs:

--- a/.azure/azure-pipelines.yaml
+++ b/.azure/azure-pipelines.yaml
@@ -22,15 +22,6 @@ steps:
       arguments: 'download'
       workingDirectory: '$(System.DefaultWorkingDirectory)'
 
-  - script: |
-      which go
-      go version
-
-      which helm
-      helm version
-    displayName: 'Versions'
-    workingDirectory: '$(System.DefaultWorkingDirectory)'
-
   - task: Go@0
     displayName: 'Test'
     inputs:

--- a/definitions/aad-pod-identity/README.md
+++ b/definitions/aad-pod-identity/README.md
@@ -1,0 +1,49 @@
+# Azure Active Directory - Pod Identity
+
+This [fabrikate](https://github.com/microsoft/fabrikate) component installs [aad-pod-identity](https://github.com/Azure/aad-pod-identity) on your cluster.
+
+### Requirements
+
+- The [fabrikate](http://github.com/microsoft/fabrikate/releases) cli tool installed locally
+- The [helm](https://github.com/helm/helm/releases) cli tool installed locally
+- The kubectl cli tool installed locally
+
+#### Optional requirements for helper script
+
+- [azure-cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [jq](https://stedolan.github.io/jq/)
+- [yq](https://github.com/mikefarah/yq#install)
+
+### Installing aad-pod-identity
+
+1. In a terminal window, install the stack dependencies:
+
+```
+fab install
+```
+
+2. In a terminal window, run the helper script:
+
+This script looks in a resource group for Managed Identities and merges them into the config file of your choosing. If no config argument is given it will default to `./config/common.yaml`
+
+#### Usage
+```
+./scripts/get-pod-identities.sh <resource-group-name> <config-file-name>
+```
+
+#### Example
+```
+./scripts/get-pod-identities.sh rg-bedrock-azure-mi ./config/common.yaml
+```
+
+3. In a terminal window, generate the stack:
+
+```
+fab generate prod
+```
+
+4. Apply the generated stack manifests:
+
+```
+kubectl apply -f ./generated/prod/ --recursive
+```

--- a/definitions/aad-pod-identity/component.yaml
+++ b/definitions/aad-pod-identity/component.yaml
@@ -1,0 +1,13 @@
+name: pod-identity
+subcomponents:
+# Workaround for aad-pod-identity Helm Chart not generating CRDs
+- name: aad-pod-identity-crds
+  type: static
+  method: http
+  source: https://raw.githubusercontent.com/Azure/aad-pod-identity/v1.6.3/charts/aad-pod-identity/crds/crd.yaml
+- name: aad-pod-identity
+  type: helm
+  method: helm
+  source: https://raw.githubusercontent.com/Azure/aad-pod-identity/v1.6.3/charts
+  path: aad-pod-identity
+  version: 2.0.2

--- a/definitions/aad-pod-identity/component.yaml
+++ b/definitions/aad-pod-identity/component.yaml
@@ -1,4 +1,6 @@
 name: pod-identity
+type: static
+path: "./manifests"
 subcomponents:
 # Workaround for aad-pod-identity Helm Chart not generating CRDs
 - name: aad-pod-identity-crds

--- a/definitions/aad-pod-identity/config/common.yaml
+++ b/definitions/aad-pod-identity/config/common.yaml
@@ -1,0 +1,19 @@
+config:
+subcomponents:
+  aad-pod-identity:
+    namespace: aad-pod-identity
+    injectNamespace: true
+    installCRDs: true
+    config:
+      mic:
+        prometheusPort: 9090
+        podAnnotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9090"
+          prometheus.io/path: "/metrics"
+      nmi:
+        prometheusPort: 9090
+        podAnnotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9090"
+          prometheus.io/path: "/metrics"

--- a/definitions/aad-pod-identity/manifests/aad-pod-identity-namespace.yaml
+++ b/definitions/aad-pod-identity/manifests/aad-pod-identity-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aad-pod-identity

--- a/definitions/aad-pod-identity/scripts/get-pod-identities.sh
+++ b/definitions/aad-pod-identity/scripts/get-pod-identities.sh
@@ -1,0 +1,27 @@
+#/bin/bash
+
+CONFIG_FILE=${2:-"./config/common.yaml"}
+
+IDENTITIES=$(az identity list -g "$1" --query "[*].{id:id,name:name,clientId:clientId}")
+for identity in $(echo "${IDENTITIES}" | jq -r '.[] | @base64'); do
+  ID_CLIENT_ID=$(echo ${identity} | base64 --decode | jq -r '.clientId')
+  ID_RESRCE_ID=$(echo ${identity} | base64 --decode | jq -r '.id')
+  ID_NAME=$(echo ${identity} | base64 --decode | jq -r '.name')
+
+  TMP_FILE=$(mktemp)
+
+  # create the AzureIdentity object for the aad-pod-identity helm chart
+  yq write ${TMP_FILE} 'name' "${ID_NAME}" -i --style double
+  yq write ${TMP_FILE} 'namespace' 'default' -i --style double
+  yq write ${TMP_FILE} 'type' '0' -i
+  yq write ${TMP_FILE} 'resourceID' "${ID_RESRCE_ID}" -i --style double
+  yq write ${TMP_FILE} 'clientID' "${ID_CLIENT_ID}" -i --style double
+  yq write ${TMP_FILE} 'binding.name' "${ID_NAME}-binding" -i --style double
+  yq write ${TMP_FILE} 'binding.selector' "${ID_NAME}" -i --style double
+
+  # nest the object to match the config for aad-pod-identity
+  yq prefix ${TMP_FILE} 'subcomponents.aad-pod-identity.config.azureIdentities[+]' -i
+
+  # merge the temp file and the proper config file
+  yq merge ${CONFIG_FILE} ${TMP_FILE} -i
+done


### PR DESCRIPTION
This definition will deploy the aad-pod-identity helm chart and CRDs.

Notes:
- Because of the way the CRDs are defined in the `aad-pod-identity` helm chart, we must explicitly deploy the CRDs because the helm chart will not generate them
- The git tag v1.6.3 correlates to the 2.0.2 release of the helm chart, hence the difference in the version in the url and the helm chart version